### PR TITLE
Explicitly specify freezer to set up for LXC

### DIFF
--- a/container/lxc.conf
+++ b/container/lxc.conf
@@ -19,4 +19,4 @@
 # cgroup controllers to set up, all if none specified.
 # NOTE: Enabling cpusets can lead to unexpected resource limiting if
 # a device uses frequent hotplugging, e.g. devices running mpdecision.
-lxc.cgroup.use = cpuacct,devices
+lxc.cgroup.use = cpuacct,devices,freezer


### PR DESCRIPTION
Hi @pdsouza ,

I have ported maruos to a tablet, but I found a strange problem, the LXC will
restart failed after stopping it with much probability.  So I just use `lxc-start` and
`lxc-stop` to operate LXC, and it reproduces the problem with some log info like
resource under `/sys/fs/cgroup` is busy.  I try to append `freezer` to  `lxc.cgroup.use` 
to let LXC use `freezer controller` and it fixes the problem.

Thanks.