### PR TITLE
Ignore sub-directories blueprints/installer/mflinger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-blueprints/*
-installer/*
-mflinger/*
+blueprints
+installer
+mflinger
 prebuilts/desktop-rootfs.tar.gz


### PR DESCRIPTION
Old .gitignore rules ignore changes in
blueprints/installer/mflinger, but we can see the changes of
vendor/maruos when we use repo status to show the diff in
the top directory. So new .gitignore rules are to 
ignore sub-directories directly, instead of content in 
sub-directories.