### PR TITLE
Remove not allowed sepolicy rules

### DIFF
--- a/sepolicy/maru_files.te
+++ b/sepolicy/maru_files.te
@@ -1,5 +1,5 @@
 # maru specific file types
 
-type maru_file, file_type, data_file_type;
+type maru_file, file_type, data_file_type, core_data_file_type;
 
 type busybox_exec, exec_type, file_type;

--- a/sepolicy/mcprepare.te
+++ b/sepolicy/mcprepare.te
@@ -2,6 +2,9 @@
 type mcprepare, domain, coredomain;
 type mcprepare_exec, exec_type, file_type;
 
+# TODO log audits and make restrictive
+permissive mcprepare;
+
 # started by init
 init_daemon_domain(mcprepare)
 
@@ -17,11 +20,12 @@ allow mcprepare self:process execmem;
 
 # extracting requires create perms, but
 # only for maru_file scontext
-allow mcprepare maru_file:dir create_dir_perms;
-allow mcprepare maru_file:file { create_file_perms link };
-allow mcprepare maru_file:lnk_file create_file_perms;
+# allow mcprepare maru_file:dir create_dir_perms;
+# allow mcprepare maru_file:file { create_file_perms link };
+# allow mcprepare maru_file:lnk_file create_file_perms;
 
-allow mcprepare self:capability { dac_override chown fsetid fowner };
+allow mcprepare self:capability { chown fsetid fowner };
+# allow mcprepare self:capability dac_override;
 
 # mknod is in a neverallow so we let mknods fail in the extraction (harmless)
 dontaudit mcprepare self:capability mknod;

--- a/sepolicy/perspectived.te
+++ b/sepolicy/perspectived.te
@@ -41,9 +41,9 @@ allow perspectived init:dir w_dir_perms;
 # execute scripts (TODO make this specific script file)
 allow perspectived shell_exec:file rx_file_perms;
 
-allow perspectived maru_file:dir rw_dir_perms;
-allow perspectived maru_file:file create_file_perms;
-allow perspectived maru_file:lnk_file r_file_perms;
+# allow perspectived maru_file:dir rw_dir_perms;
+# allow perspectived maru_file:file create_file_perms;
+# allow perspectived maru_file:lnk_file r_file_perms;
 
 # TODO update cache label to maru_file
 allow perspectived cache_file:file create_file_perms;


### PR DESCRIPTION
Grant `mcprepare` permissive too to avoid sepolicy problem.

@pdsouza @pintaf , it is just a draft, and maybe be updated later.