### PR TITLE
Add permissive for mcprepare

### DIFF
--- a/sepolicy/mcprepare.te
+++ b/sepolicy/mcprepare.te
@@ -2,6 +2,8 @@
 type mcprepare, domain, coredomain;
 type mcprepare_exec, exec_type, file_type;
 
+permissive mcprepare;
+
 # started by init
 init_daemon_domain(mcprepare)
 


### PR DESCRIPTION
It will allow `mcprepare` to run correctly when booting