### PR TITLE
Add sepolicy to allow service manager add perspective service

### DIFF
--- a/sepolicy/perspectived.te
+++ b/sepolicy/perspectived.te
@@ -26,6 +26,7 @@ binder_service(perspectived)
 
 # register Binder service
 allow perspectived mperspective_service:service_manager add;
+allow perspectived default_android_service:service_manager add;
 
 # allow system_server to find perspectived
 allow system_server mperspective_service:service_manager find;

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,0 +1,2 @@
+allow system_server default_android_hwservice:hwservice_manager find;
+allow system_server default_android_service:service_manager { add find };


### PR DESCRIPTION
Use the following steps to get needed sepolicy:

```
adb logcat | grep avc | tee avc.log
audit2allow -i avc.log
```