### PR TITLE
Add variable to allow other vendor prebuilt rootfs

### DIFF
--- a/device-maru.mk
+++ b/device-maru.mk
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+# lazy set prebuilt rootfs to maru if empty
+PREBUILT_REPO ?= maruos
+
 # early build definitions for maru
 include $(LOCAL_PATH)/maru_build.mk
 
@@ -24,10 +27,15 @@ PRODUCT_COPY_FILES += \
 
 # container
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/prebuilts/desktop-rootfs.tar.gz:system/maru/containers/default/rootfs.tar.gz \
     $(LOCAL_PATH)/container/default/config:system/maru/containers/default/config \
     $(LOCAL_PATH)/container/default/fstab:system/maru/containers/default/fstab \
     $(LOCAL_PATH)/container/mcprepare.sh:system/bin/mcprepare
+
+# prebuilt rootfs
+ifeq ($(PREBUILT_REPO),maruos)
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/prebuilts/desktop-rootfs.tar.gz:system/maru/containers/default/rootfs.tar.gz
+endif
 
 # LXC
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
This adds a variable `PREBUILT_REPO` lazily-set to `maruos`, where the prebuilt is only copied if the variable is indeed `maruos`, allowing other vendor repos to copy their prebuilt rootfs archives manually. This cuts out the otherwise required step of copying the file first to vendor/maruos/prebuilts, then to system/maru/containers/default/.