### PR TITLE
Add support for vendor-defined bootanimation

### DIFF
--- a/device-maru.mk
+++ b/device-maru.mk
@@ -85,4 +85,6 @@ endif
 
 WITHOUT_CHECK_API := true
 
+ifneq ($(MARU_VERSION),)
 TARGET_BOOTANIMATION := $(LOCAL_PATH)/prebuilts/mbootanim.zip
+endif


### PR DESCRIPTION
Allow external vendors to set bootanimation without being overwritten by maru--checks if maru version is set before setting `TARGET_BOOTANIMATION`.

Signed-off-by: Thomas Makin <halorocker89@gmail.com>