### PR TITLE
Support vendors overriding desktop rootfs img

### DIFF
--- a/device-maru.mk
+++ b/device-maru.mk
@@ -23,8 +23,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.maru.rc:root/init.maru.rc
 
 # container
+PRODUCT_PACKAGES += rootfs.tar.gz
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/prebuilts/desktop-rootfs.tar.gz:system/maru/containers/default/rootfs.tar.gz \
     $(LOCAL_PATH)/container/default/config:system/maru/containers/default/config \
     $(LOCAL_PATH)/container/default/fstab:system/maru/containers/default/fstab \
     $(LOCAL_PATH)/container/mcprepare.sh:system/bin/mcprepare

--- a/prebuilts/Android.mk
+++ b/prebuilts/Android.mk
@@ -16,4 +16,26 @@
 #
 LOCAL_PATH := $(call my-dir)
 
+# TARGET_DESKTOP_ROOTFS can be set in vendor makefiles to override the default
+# desktop rootfs image for Maru. Note that the path must be relative to the
+# AOSP workspace root directory, which can easily be done by prefixing the path
+# with $(LOCAL_PATH).
+ifeq ($(TARGET_DESKTOP_ROOTFS),)
+  TARGET_DESKTOP_ROOTFS := $(LOCAL_PATH)/desktop-rootfs.tar.gz
+endif
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := rootfs.tar.gz
+LOCAL_MODULE_TAGS  := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT)/maru/containers/default
+
+# Instead of using LOCAL_SRC_FILES and $(BUILD_PREBUILT), we explicitly set up
+# the rule ourselves so that we can copy a rootfs path from outside of this
+# directory if a vendor overrides TARGET_DESKTOP_ROOTFS.
+include $(BUILD_SYSTEM)/base_rules.mk
+$(LOCAL_BUILT_MODULE): $(TARGET_DESKTOP_ROOTFS)
+	@mkdir -p $(dir $@)
+	@cp $(TARGET_DESKTOP_ROOTFS) $@
+
 include $(call all-makefiles-under, $(LOCAL_PATH))


### PR DESCRIPTION
This commit allows vendors to override the default desktop rootfs image. To do this, we create a new module for `rootfs.tar.gz` and create a new variable `TARGET_DESKTOP_ROOTFS` that vendors can override to select a custom desktop rootfs image. If `TARGET_DESKTOP_ROOTFS` is not set, then we copy over our usual `vendor/maruos/prebuilts/desktop-rootfs.tar.gz`.

Also, if we ever integrate building the desktop rootfs directly into the Android build, this module would be a good place to call into our blueprints desktop building script.

Signed-off-by: Preetam D'Souza <preetamjdsouza@gmail.com>