### PR TITLE
sepolicy: Allow mflinger to access gpu device

### DIFF
--- a/sepolicy/mflinger.te
+++ b/sepolicy/mflinger.te
@@ -18,3 +18,4 @@ allow mflinger surfaceflinger_service:service_manager find;
 
 # allow mflinger to read the ion buffer used by mclient
 allow mflinger ion_device:chr_file r_file_perms;
+allow mflinger gpu_device:chr_file { read write };


### PR DESCRIPTION
The new rules are got from sargo device.