### PR TITLE
Fix sepolicy for treble devices in maru-0.7

### DIFF
--- a/sepolicy/maru_files.te
+++ b/sepolicy/maru_files.te
@@ -1,5 +1,5 @@
 # maru specific file types
 
-type maru_file, file_type, data_file_type;
+type maru_file, file_type, data_file_type, core_data_file_type;
 
 type busybox_exec, exec_type, file_type;


### PR DESCRIPTION
  In maru-0.7, treble devices fail to build because of two never
  allow rules in system/sepolicyconflict with type maru_files.
  These rules are on lines 812 and 826. In the past, these have been
  removed prior to build. This should allow for other treble
  devices to build without hitting this issue.
  To fix this, core_data_file_type was added to maru_file.

Signed-off-by: Chris White <bootlessxfly@gmail.com>