### PR TITLE
Fixed system_server violation against default_android_service

### DIFF
--- a/sepolicy/default_android_service_maru.te
+++ b/sepolicy/default_android_service_maru.te
@@ -1,0 +1,4 @@
+# This is being used as a wrapper around default_android_hwservice and default_android_service
+
+type default_android_hwservice_maru, hwservice_manager_type;
+type default_android_service_maru,   service_manager_type;

--- a/sepolicy/perspectived.te
+++ b/sepolicy/perspectived.te
@@ -26,7 +26,7 @@ binder_service(perspectived)
 
 # register Binder service
 allow perspectived mperspective_service:service_manager add;
-allow perspectived default_android_service:service_manager add;
+allow perspectived default_android_service_maru:service_manager add;
 
 # allow system_server to find perspectived
 allow system_server mperspective_service:service_manager find;

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,2 +1,2 @@
-allow system_server default_android_hwservice:hwservice_manager find;
-allow system_server default_android_service:service_manager { add find };
+allow system_server default_android_hwservice_maru:hwservice_manager find;
+allow system_server default_android_service_maru:service_manager { add find };


### PR DESCRIPTION
In Android Pie, you can not allow service_manager add in the
default labels default_android_hwservice and default_android_service
Created two new types default_android_hwservice_maru and
default_android_service with the exact same atrributes in oreder
to pass this neverallow.

Signed-off-by: Chris White <bootlessxfly@gmail.com>