### PR TITLE
Remove attribute dac_override from type mcprepare

### DIFF
--- a/sepolicy/mcprepare.te
+++ b/sepolicy/mcprepare.te
@@ -23,7 +23,7 @@ allow mcprepare maru_file:dir create_dir_perms;
 allow mcprepare maru_file:file { create_file_perms link };
 allow mcprepare maru_file:lnk_file create_file_perms;
 
-allow mcprepare self:capability { dac_override chown fsetid fowner };
+allow mcprepare self:capability { chown fsetid fowner };
 
 # mknod is in a neverallow so we let mknods fail in the extraction (harmless)
 dontaudit mcprepare self:capability mknod;


### PR DESCRIPTION
mcprepare violates a neverallow rule around dac_override_allow.
mcprepare simpily needs to be added to dac_override_allow. The
issue comes in that type mcprepare is not loaded untill later in
the sepolicycheck test. This causes the build to fail with a type
not found error when adding mcprepare to dac_override_allow. To
get around this, dac_override_allow has been added to mcprepare.te
after the declaration of types. I added mcprepare to this custom
dac_override_allow to add it as an exception. Then, I added
the original dac_override newverallow rule so that the check
included mcprepare. Inside of system/sepolicy/public/domain.te,
the neverallow policy for dac_overide needs to be removed so that
it is reran once mcprepare is recognized. This allows for the check to
pass without being disbaled.

While this does require changes to system/sepolicy, this would need to
be done regardless as mcprepare would need to be added to domain.te via
dac_override_allow.

Ideally, this could have been set and overridden inside of
vendor/maruos. I tried and was unable to do so.

Signed-off-by: Chris White <bootlessxfly@gmail.com>